### PR TITLE
[FEATURE] Import link text from EXT:tl_ttnews_linktext if present

### DIFF
--- a/Classes/Service/Import/TTNewsNewsDataProviderService.php
+++ b/Classes/Service/Import/TTNewsNewsDataProviderService.php
@@ -98,7 +98,7 @@ class TTNewsNewsDataProviderService implements \Tx_News_Service_Import_DataProvi
 				'categories' => $this->getCategories($row['uid']),
 				'media' => $this->getMedia($row),
 				'related_files' => $this->getFiles($row),
-				'related_links' => $this->getRelatedLinks($row['links']),
+				'related_links' => array_key_exists('tx_tlnewslinktext_linktext', $row) ? $this->getRelatedLinksTlNewsLinktext($row['links'], $row['tx_tlnewslinktext_linktext']) : $this->getRelatedLinks($row['links']),
 				'content_elements' => $row['tx_rgnewsce_ce'],
 				'import_id' => $row['uid'],
 				'import_source' => $this->importSource
@@ -250,6 +250,39 @@ class TTNewsNewsDataProviderService implements \Tx_News_Service_Import_DataProvi
 				'title' => $title,
 				'description' => '',
 			);
+		}
+		return $links;
+	}
+
+	/**
+	 * Get link elements to be imported when using EXT:tl_news_linktext
+	 * This extension adds an additional field for link texts that are separated by a line break
+	 *
+	 * @param string $newsLinks
+	 * @param string $newsLinksTexts
+	 * @return array
+	 */
+	protected function getRelatedLinksTlNewsLinktext($newsLinks, $newsLinksTexts) {
+		$links = array();
+
+		if (empty($newsLinks)) {
+			return $links;
+		}
+
+		$newsLinks = str_replace("\r\n", "\n", $newsLinks);
+		$newsLinksTexts = str_replace("\r\n", "\n", $newsLinksTexts);
+
+		$linkList = GeneralUtility::trimExplode("\n", $newsLinks, TRUE);
+		$linkTextList = GeneralUtility::trimExplode("\n", $newsLinksTexts, TRUE);
+
+		$iterator = 0;
+		foreach ($linkList as $uri) {
+			$links[] = array(
+				'uri' => $uri,
+				'title' => array_key_exists($iterator, $linkTextList) ? $linkTextList[$iterator] : $uri,
+				'description' => '',
+			);
+			$iterator++;
 		}
 		return $links;
 	}

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -18,6 +18,7 @@ Features
 
 - DAM support, images and files will be converted to ext:news (FAL)media elements
 - Converts jg_youtubeinnews YouTube links to ext:news media elements
+- Converts tl_news_linktext related links to ext:news link elements
 
 Requirements
 ------------

--- a/Readme.rst
+++ b/Readme.rst
@@ -9,6 +9,7 @@ This is an extraction of the tt_news importer code original from `EXT:News` enha
 
 - DAM support
 - Converts jg_youtubeinnews YouTube links to ext:news media elements
+- Converts tl_news_linktext related links to ext:news link elements
 
 **Requirements**
 


### PR DESCRIPTION
EXT:tl_ttnews_linktext adds an additional field "Link text" to tt_news where you add one link text per line. If this extension is installed, no "<link" tags are used in the "links" field so the importer must treat these links differently.
