### PR TITLE
[FEATURE] Importer for event data of mbl_newsevent to fields of roq_newsevent

### DIFF
--- a/Classes/Jobs/MblNewseventImportJob.php
+++ b/Classes/Jobs/MblNewseventImportJob.php
@@ -1,0 +1,60 @@
+<?php
+namespace BeechIt\NewsTtnewsimport\Jobs;
+
+/***************************************************************
+*  Copyright notice
+*
+*  (c) 2010 Georg Ringer <typo3@ringerge.org>
+*  All rights reserved
+*
+*  This script is part of the TYPO3 project. The TYPO3 project is
+*  free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2 of the License, or
+*  (at your option) any later version.
+*
+*  The GNU General Public License can be found at
+*  http://www.gnu.org/copyleft/gpl.html.
+*
+*  This script is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU General Public License for more details.
+*
+*  This copyright notice MUST APPEAR in all copies of the script!
+***************************************************************/
+
+/**
+ * Import job
+ *
+ * @package TYPO3
+ * @subpackage news_ttnewsimport
+ */
+class MblNewseventImportJob extends \Tx_News_Jobs_AbstractImportJob {
+	/**
+	 * @var int
+	 */
+	protected $numberOfRecordsPerRun = 30;
+
+	/**
+	 * Inject import dataprovider service
+	 *
+	 * @param \BeechIt\NewsTtnewsimport\Service\Import\MblNewseventDataProviderService $importDataProviderService
+	 * @return void
+	 */
+	public function injectImportDataProviderService(\BeechIt\NewsTtnewsimport\Service\Import\MblNewseventDataProviderService
+		$importDataProviderService) {
+
+		$this->importDataProviderService = $importDataProviderService;
+	}
+
+	/**
+	 * Inject import service
+	 *
+	 * @param \BeechIt\NewsTtnewsimport\Service\Import\MblNewseventImportService $importService
+	 * @return void
+	 */
+	public function injectImportService(\BeechIt\NewsTtnewsimport\Service\Import\MblNewseventImportService $importService) {
+		$this->importService = $importService;
+	}
+}

--- a/Classes/Service/Import/MblNewseventDataProviderService.php
+++ b/Classes/Service/Import/MblNewseventDataProviderService.php
@@ -1,0 +1,92 @@
+<?php
+namespace BeechIt\NewsTtnewsimport\Service\Import;
+
+/***************************************************************
+*  Copyright notice
+*
+*  (c) 2011 Nikolas Hagelstein <nikolas.hagelstein@gmail.com>
+*  All rights reserved
+*
+*  This script is part of the TYPO3 project. The TYPO3 project is
+*  free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2 of the License, or
+*  (at your option) any later version.
+*
+*  The GNU General Public License can be found at
+*  http://www.gnu.org/copyleft/gpl.html.
+*
+*  This script is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU General Public License for more details.
+*
+*  This copyright notice MUST APPEAR in all copies of the script!
+***************************************************************/
+
+use \TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * tt_news ImportService
+ *
+ * @package TYPO3
+ * @subpackage news_ttnewsimport
+ */
+class MblNewseventDataProviderService implements \Tx_News_Service_Import_DataProviderServiceInterface, \TYPO3\CMS\Core\SingletonInterface  {
+
+	/**
+	 * Get total record count
+	 *
+	 * @return integer
+	 */
+	public function getTotalRecordCount() {
+		$res = $GLOBALS['TYPO3_DB']->exec_SELECTquery('count(*)',
+			'tt_news',
+			'deleted=0 AND t3ver_oid = 0 AND t3ver_wsid = 0 AND tx_mblnewsevent_isevent=1'
+		);
+
+		list($count) = $GLOBALS['TYPO3_DB']->sql_fetch_row($res);
+		$GLOBALS['TYPO3_DB']->sql_free_result($res);
+
+		return (int)$count;
+	}
+
+	/**
+	 * Get the partial import data, based on offset + limit
+	 *
+	 * @param integer $offset offset
+	 * @param integer $limit limit
+	 * @return array
+	 */
+	public function getImportData($offset = 0, $limit = 50) {
+		$importData = array();
+
+		$res = $GLOBALS['TYPO3_DB']->exec_SELECTquery('*',
+			'tt_news',
+			'deleted=0 AND t3ver_oid = 0 AND t3ver_wsid = 0 AND tx_mblnewsevent_isevent=1',
+			'',
+			'',
+			$offset . ',' . $limit
+		);
+
+		while ($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res)) {
+
+			$importData[] = array(
+				'uid' => $row['uid'],
+				// The following fields cannot be migrated because they are missing in roq_newsevent:
+				// tx_mblnewsevent_organizer, tx_mblnewsevent_hasregistration, tx_mblnewsevent_reg*, tx_mblnewsevent_price*
+				'tx_mblnewsevent_isevent' => $row['tx_mblnewsevent_isevent'],
+				'tx_mblnewsevent_from' => $row['tx_mblnewsevent_from'],
+				'tx_mblnewsevent_fromtime' => $row['tx_mblnewsevent_fromtime'],
+				'tx_mblnewsevent_to' => $row['tx_mblnewsevent_to'],
+				'tx_mblnewsevent_totime' => $row['tx_mblnewsevent_totime'],
+				'tx_mblnewsevent_where' => $row['tx_mblnewsevent_where'],
+
+			);
+		}
+		$GLOBALS['TYPO3_DB']->sql_free_result($res);
+
+		return $importData;
+	}
+
+}

--- a/Classes/Service/Import/MblNewseventImportService.php
+++ b/Classes/Service/Import/MblNewseventImportService.php
@@ -1,0 +1,94 @@
+<?php
+namespace BeechIt\NewsTtnewsimport\Service\Import;
+/**
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * MblNewsevent Import Service
+ *
+ * @package TYPO3
+ * @subpackage tx_news
+ * @author Lorenz Ulrich <lorenz.ulrich@visol.ch>
+ */
+class MblNewseventImportService extends \Tx_News_Domain_Service_AbstractImportService {
+
+	/**
+	 * @var \TYPO3\CMS\Core\Database\DatabaseConnection
+	 */
+	protected $databaseConnection;
+
+	/**
+	 * @var \Tx_News_Domain_Repository_NewsRepository
+	 * @inject
+	 */
+	protected $newsRepository;
+
+	public function __construct() {
+		/** @var \TYPO3\CMS\Core\Log\Logger $logger */
+		$logger = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\CMS\Core\Log\LogManager')->getLogger(__CLASS__);
+		$this->logger = $logger;
+		$this->databaseConnection = $GLOBALS['TYPO3_DB'];
+
+		parent::__construct();
+	}
+
+	/**
+	 * Import
+	 *
+	 * We don't use the Extbase repository here because we only write additional data to News records and
+	 * cannot be sure if the Extbase objects configuration for EXT:roq_newsevent is properly loaded at this point
+	 *
+	 * @param array $importData
+	 * @param array $importItemOverwrite
+	 * @param array $settings
+	 * @return void
+	 */
+	public function import(array $importData, array $importItemOverwrite = array(), $settings = array()) {
+		$this->settings = $settings;
+		$this->logger->info(sprintf('Starting import for the event data of %s records', count($importData)));
+
+		/** @var \TYPO3\CMS\Core\DataHandling\DataHandler $dataHandler */
+		$dataHandler = GeneralUtility::makeInstance('TYPO3\CMS\Core\DataHandling\DataHandler');
+		// keep timestamps untouched
+		$dataHandler->dontProcessTransformations = TRUE;
+
+		foreach ($importData as $importItem) {
+
+			$newsRecord = $this->getNewsRecordByImportId($importItem['uid']);
+
+			$data = array();
+			$data['tx_news_domain_model_news'][$newsRecord['uid']]= array(
+				'tx_roqnewsevent_is_event' => $importItem['tx_mblnewsevent_isevent'],
+				'tx_roqnewsevent_startdate' => $importItem['tx_mblnewsevent_from'],
+				'tx_roqnewsevent_starttime' => $importItem['tx_mblnewsevent_fromtime'],
+				'tx_roqnewsevent_enddate' => $importItem['tx_mblnewsevent_to'],
+				'tx_roqnewsevent_endtime' => $importItem['tx_mblnewsevent_totime'],
+				'tx_roqnewsevent_location' => $importItem['tx_mblnewsevent_where']
+			);
+			$dataHandler->start($data, array());
+			$dataHandler->process_datamap();
+
+		}
+
+	}
+
+	/**
+	 * @param integer $ttNewsUid
+	 * @return array
+	 */
+	public function getNewsRecordByImportId($ttNewsUid) {
+		return $this->databaseConnection->exec_SELECTgetSingleRow('uid', 'tx_news_domain_model_news', 'import_id=' . (int)$ttNewsUid);
+	}
+
+}

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -19,6 +19,7 @@ Features
 - DAM support, images and files will be converted to ext:news (FAL)media elements
 - Converts jg_youtubeinnews YouTube links to ext:news media elements
 - Converts tl_news_linktext related links to ext:news link elements
+- Imports data from EXT:mbl_newsevent to the available fields of EXT:roq_newsevent (News event extension for EXT:news)
 
 Requirements
 ------------

--- a/Readme.rst
+++ b/Readme.rst
@@ -10,6 +10,7 @@ This is an extraction of the tt_news importer code original from `EXT:News` enha
 - DAM support
 - Converts jg_youtubeinnews YouTube links to ext:news media elements
 - Converts tl_news_linktext related links to ext:news link elements
+- Imports data from EXT:mbl_newsevent to the available fields of EXT:roq_newsevent (News event extension for EXT:news)
 
 **Requirements**
 

--- a/Resources/Private/Language/locallang_be.xml
+++ b/Resources/Private/Language/locallang_be.xml
@@ -8,6 +8,7 @@
 		<languageKey index="default" type="array">
 			<label index="ttnews_importer_title">Import tt_news news records</label>
 			<label index="ttnewscategory_importer_title">Import tt_news category records</label>
+			<label index="mblnewsevent_importer_title">Import mbl_newsevent data to existing news records</label>
 		</languageKey>
 
 		<languageKey index="da" type="array">
@@ -18,6 +19,7 @@
 		<languageKey index="de" type="array">
 			<label index="ttnews_importer_title">Import von tt_news Datensätzen</label>
 			<label index="ttnewscategory_importer_title">Import von tt_news Kategorien</label>
+			<label index="mblnewsevent_importer_title">Import von mbl_newsevent Daten in bestehende News-Records</label>
 		</languageKey>
 
 		<languageKey index="nl" type="array">

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -11,3 +11,7 @@ if (!defined('TYPO3_MODE')) {
 	'BeechIt\\NewsTtnewsimport\\Jobs\\TTNewsCategoryImportJob',
 	'LLL:EXT:news_ttnewsimport/Resources/Private/Language/locallang_be.xml:ttnewscategory_importer_title',
 	'');
+\Tx_News_Utility_ImportJob::register(
+	'BeechIt\\NewsTtnewsimport\\Jobs\\MblNewseventImportJob',
+	'LLL:EXT:news_ttnewsimport/Resources/Private/Language/locallang_be.xml:mblnewsevent_importer_title',
+	'');


### PR DESCRIPTION
mbl_newsevent is the most popular News event extension for tt_news, while roq_newsevent is the most popular News event extension for EXT:news. A new importer copies the data of mbl_newsevent to all available fields of roq_newsevent.

I wrote an own importer task instead of extending the one for news records because the news event properties are not available in the EXT:news news importer making it impossible to import the data through the Extbase repository.
