### PR TITLE
[TASK] Fix namespace changes from EXT:news

### DIFF
--- a/Classes/Jobs/DamMediaTagConversionJob.php
+++ b/Classes/Jobs/DamMediaTagConversionJob.php
@@ -13,6 +13,7 @@ namespace BeechIt\NewsTtnewsimport\Jobs;
  *
  * The TYPO3 project - inspiring people to share!
  */
+use GeorgRinger\News\Domain\Service\AbstractImportService;
 
 /**
  * Import job
@@ -20,7 +21,7 @@ namespace BeechIt\NewsTtnewsimport\Jobs;
  * @package TYPO3
  * @subpackage news_ttnewsimport
  */
-class DamMediaTagConversionJob extends \Tx_News_Jobs_AbstractImportJob {
+class DamMediaTagConversionJob extends AbstractImportService {
 	/**
 	 * @var int
 	 */

--- a/Classes/Jobs/MblNewseventImportJob.php
+++ b/Classes/Jobs/MblNewseventImportJob.php
@@ -23,6 +23,7 @@ namespace BeechIt\NewsTtnewsimport\Jobs;
 *
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
+use GeorgRinger\News\Domain\Service\AbstractImportService;
 
 /**
  * Import job
@@ -30,7 +31,7 @@ namespace BeechIt\NewsTtnewsimport\Jobs;
  * @package TYPO3
  * @subpackage news_ttnewsimport
  */
-class MblNewseventImportJob extends \Tx_News_Jobs_AbstractImportJob {
+class MblNewseventImportJob extends AbstractImportService {
 	/**
 	 * @var int
 	 */

--- a/Classes/Jobs/TTNewsCategoryImportJob.php
+++ b/Classes/Jobs/TTNewsCategoryImportJob.php
@@ -23,6 +23,7 @@ namespace BeechIt\NewsTtnewsimport\Jobs;
 *
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
+use GeorgRinger\News\Jobs\AbstractImportJob;
 
 /**
  * Import job
@@ -30,7 +31,7 @@ namespace BeechIt\NewsTtnewsimport\Jobs;
  * @package TYPO3
  * @subpackage news_ttnewsimport
  */
-class TTNewsCategoryImportJob extends \Tx_News_Jobs_AbstractImportJob {
+class TTNewsCategoryImportJob extends AbstractImportJob {
 
 	/**
 	 * Inject import dataprovider service

--- a/Classes/Jobs/TTNewsNewsImportJob.php
+++ b/Classes/Jobs/TTNewsNewsImportJob.php
@@ -23,6 +23,8 @@ namespace BeechIt\NewsTtnewsimport\Jobs;
 *
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
+use GeorgRinger\News\Domain\Service\NewsImportService;
+use GeorgRinger\News\Jobs\AbstractImportJob;
 
 /**
  * Import job
@@ -30,7 +32,7 @@ namespace BeechIt\NewsTtnewsimport\Jobs;
  * @package TYPO3
  * @subpackage news_ttnewsimport
  */
-class TTNewsNewsImportJob extends \Tx_News_Jobs_AbstractImportJob {
+class TTNewsNewsImportJob extends AbstractImportJob {
 	/**
 	 * @var int
 	 */
@@ -55,10 +57,10 @@ class TTNewsNewsImportJob extends \Tx_News_Jobs_AbstractImportJob {
 	/**
 	 * Inject import service
 	 *
-	 * @param \Tx_News_Domain_Service_NewsImportService $importService
+	 * @param NewsImportService $importService
 	 * @return void
 	 */
-	public function injectImportService(\Tx_News_Domain_Service_NewsImportService $importService) {
+	public function injectImportService(NewsImportService $importService) {
 		$this->importService = $importService;
 	}
 }

--- a/Classes/Service/Import/DamMediaTagConversionService.php
+++ b/Classes/Service/Import/DamMediaTagConversionService.php
@@ -12,6 +12,7 @@ namespace BeechIt\NewsTtnewsimport\Service\Import;
  *
  * The TYPO3 project - inspiring people to share!
  */
+use GeorgRinger\News\Domain\Service\AbstractImportService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -21,7 +22,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * @subpackage tx_news
  * @author Lorenz Ulrich <lorenz.ulrich@visol.ch>
  */
-class DamMediaTagConversionService extends \Tx_News_Domain_Service_AbstractImportService {
+class DamMediaTagConversionService extends AbstractImportService {
 
 	/**
 	 * @var \TYPO3\CMS\Core\Database\DatabaseConnection
@@ -29,7 +30,7 @@ class DamMediaTagConversionService extends \Tx_News_Domain_Service_AbstractImpor
 	protected $databaseConnection;
 
 	/**
-	 * @var \Tx_News_Domain_Repository_NewsRepository
+	 * @var \GeorgRinger\News\Domain\Repository\NewsRepository
 	 * @inject
 	 */
 	protected $newsRepository;

--- a/Classes/Service/Import/DamMediaTagDataProviderService.php
+++ b/Classes/Service/Import/DamMediaTagDataProviderService.php
@@ -13,6 +13,7 @@ namespace BeechIt\NewsTtnewsimport\Service\Import;
  *
  * The TYPO3 project - inspiring people to share!
  */
+use GeorgRinger\News\Service\Import\DataProviderServiceInterface;
 
 /**
  * tt_news ImportService
@@ -20,7 +21,7 @@ namespace BeechIt\NewsTtnewsimport\Service\Import;
  * @package TYPO3
  * @subpackage news_ttnewsimport
  */
-class DamMediaTagDataProviderService implements \Tx_News_Service_Import_DataProviderServiceInterface, \TYPO3\CMS\Core\SingletonInterface  {
+class DamMediaTagDataProviderService implements DataProviderServiceInterface, \TYPO3\CMS\Core\SingletonInterface  {
 
 	/**
 	 * Get total record count

--- a/Classes/Service/Import/MblNewseventDataProviderService.php
+++ b/Classes/Service/Import/MblNewseventDataProviderService.php
@@ -24,6 +24,7 @@ namespace BeechIt\NewsTtnewsimport\Service\Import;
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
+use GeorgRinger\News\Service\Import\DataProviderServiceInterface;
 use \TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -32,7 +33,7 @@ use \TYPO3\CMS\Core\Utility\GeneralUtility;
  * @package TYPO3
  * @subpackage news_ttnewsimport
  */
-class MblNewseventDataProviderService implements \Tx_News_Service_Import_DataProviderServiceInterface, \TYPO3\CMS\Core\SingletonInterface  {
+class MblNewseventDataProviderService implements DataProviderServiceInterface, \TYPO3\CMS\Core\SingletonInterface  {
 
 	/**
 	 * Get total record count

--- a/Classes/Service/Import/MblNewseventImportService.php
+++ b/Classes/Service/Import/MblNewseventImportService.php
@@ -12,6 +12,7 @@ namespace BeechIt\NewsTtnewsimport\Service\Import;
  *
  * The TYPO3 project - inspiring people to share!
  */
+use GeorgRinger\News\Domain\Service\AbstractImportService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -21,7 +22,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * @subpackage tx_news
  * @author Lorenz Ulrich <lorenz.ulrich@visol.ch>
  */
-class MblNewseventImportService extends \Tx_News_Domain_Service_AbstractImportService {
+class MblNewseventImportService extends AbstractImportService {
 
 	/**
 	 * @var \TYPO3\CMS\Core\Database\DatabaseConnection
@@ -29,7 +30,7 @@ class MblNewseventImportService extends \Tx_News_Domain_Service_AbstractImportSe
 	protected $databaseConnection;
 
 	/**
-	 * @var \Tx_News_Domain_Repository_NewsRepository
+	 * @var \GeorgRinger\News\Domain\Repository\NewsRepository
 	 * @inject
 	 */
 	protected $newsRepository;

--- a/Classes/Service/Import/TTNewsCategoryDataProviderService.php
+++ b/Classes/Service/Import/TTNewsCategoryDataProviderService.php
@@ -23,6 +23,7 @@ namespace BeechIt\NewsTtnewsimport\Service\Import;
 *
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
+use GeorgRinger\News\Service\Import\DataProviderServiceInterface;
 
 /**
  * tt_news category ImportService
@@ -30,7 +31,7 @@ namespace BeechIt\NewsTtnewsimport\Service\Import;
  * @package TYPO3
  * @subpackage news_ttnewsimport
  */
-class TTNewsCategoryDataProviderService implements \Tx_News_Service_Import_DataProviderServiceInterface, \TYPO3\CMS\Core\SingletonInterface {
+class TTNewsCategoryDataProviderService implements DataProviderServiceInterface, \TYPO3\CMS\Core\SingletonInterface {
 
 	protected $importSource = 'TT_NEWS_CATEGORY_IMPORT';
 

--- a/Classes/Service/Import/TTNewsCategoryImportService.php
+++ b/Classes/Service/Import/TTNewsCategoryImportService.php
@@ -12,6 +12,7 @@ namespace BeechIt\NewsTtnewsimport\Service\Import;
  *
  * The TYPO3 project - inspiring people to share!
  */
+use GeorgRinger\News\Domain\Service\CategoryImportService;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -22,7 +23,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * @subpackage tx_news
  * @author Lorenz Ulrich <lorenz.ulrich@visol.ch>
  */
-class TTNewsCategoryImportService extends \Tx_News_Domain_Service_CategoryImportService {
+class TTNewsCategoryImportService extends CategoryImportService {
 
 	/**
 	 * @var \TYPO3\CMS\Core\Database\DatabaseConnection

--- a/Classes/Service/Import/TTNewsNewsDataProviderService.php
+++ b/Classes/Service/Import/TTNewsNewsDataProviderService.php
@@ -24,6 +24,8 @@ namespace BeechIt\NewsTtnewsimport\Service\Import;
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
+use GeorgRinger\News\Domain\Model\Media;
+use GeorgRinger\News\Service\Import\DataProviderServiceInterface;
 use \TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -32,7 +34,7 @@ use \TYPO3\CMS\Core\Utility\GeneralUtility;
  * @package TYPO3
  * @subpackage news_ttnewsimport
  */
-class TTNewsNewsDataProviderService implements \Tx_News_Service_Import_DataProviderServiceInterface, \TYPO3\CMS\Core\SingletonInterface  {
+class TTNewsNewsDataProviderService implements DataProviderServiceInterface, \TYPO3\CMS\Core\SingletonInterface  {
 
 	protected $importSource = 'TT_NEWS_IMPORT';
 
@@ -331,7 +333,7 @@ class TTNewsNewsDataProviderService implements \Tx_News_Service_Import_DataProvi
 				foreach ($matches as $url) {
 					$urlInfo = parse_url($url);
 					$media[] = array(
-						'type' => \Tx_News_Domain_Model_Media::MEDIA_TYPE_MULTIMEDIA,
+						'type' => Media::MEDIA_TYPE_MULTIMEDIA,
 						'multimedia' => $url,
 						'title' => $urlInfo['host'],
 					);

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "license": "GPL-2.0+",
   "keywords": ["TYPO3 CMS"],
   "require": {
-    "typo3/cms-core": ">=6.2.4",
+    "typo3/cms-core": ">=7.0.0",
     "georgringer/news": ">=3.0.0"
   },
   "autoload": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -24,7 +24,7 @@ $EM_CONF[$_EXTKEY] = array(
 	'version' => '1.0.2',
 	'constraints' => array(
 		'depends' => array(
-			'typo3' => '6.2.4-7.99.99',
+			'typo3' => '7.0.0-7.99.99',
 			'php' => '5.3.0-0.0.0',
 			'news' => '3.0.0',
 		),

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -3,19 +3,19 @@ if (!defined('TYPO3_MODE')) {
 	die ('Access denied.');
 }
 
-\Tx_News_Utility_ImportJob::register(
+\GeorgRinger\News\Utility\ImportJob::register(
 	'BeechIt\\NewsTtnewsimport\\Jobs\\TTNewsNewsImportJob',
 	'LLL:EXT:news_ttnewsimport/Resources/Private/Language/locallang_be.xml:ttnews_importer_title',
 	'');
-\Tx_News_Utility_ImportJob::register(
+\GeorgRinger\News\Utility\ImportJob::register(
 	'BeechIt\\NewsTtnewsimport\\Jobs\\TTNewsCategoryImportJob',
 	'LLL:EXT:news_ttnewsimport/Resources/Private/Language/locallang_be.xml:ttnewscategory_importer_title',
 	'');
-\Tx_News_Utility_ImportJob::register(
+\GeorgRinger\News\Utility\ImportJob::register(
 	'BeechIt\\NewsTtnewsimport\\Jobs\\MblNewseventImportJob',
 	'LLL:EXT:news_ttnewsimport/Resources/Private/Language/locallang_be.xml:mblnewsevent_importer_title',
 	'');
-\Tx_News_Utility_ImportJob::register(
+\GeorgRinger\News\Utility\ImportJob::register(
 	'BeechIt\\NewsTtnewsimport\\Jobs\\DamMediaTagConversionJob',
 	'LLL:EXT:news_ttnewsimport/Resources/Private/Language/locallang_be.xml:dammediatag_converter_title',
 	'');


### PR DESCRIPTION
This patch fix the broken class names, make it running
again with TYPO3 7.x