### PR TITLE
[BUGFIX] place backPid into the correct sheet

### DIFF
--- a/Classes/Service/Migrate/TtNewsPluginMigrate.php
+++ b/Classes/Service/Migrate/TtNewsPluginMigrate.php
@@ -159,7 +159,7 @@ class TtNewsPluginMigrate
                     $this->addFieldToArray($new, $value, 'settings.detailPid', 'additional');
                     break;
                 case 'backPid':
-                    $this->addFieldToArray($new, $value, 'settings.backPid');
+                    $this->addFieldToArray($new, $value, 'settings.backPid', 'additional');
                     break;
                 case 'pages':
                     $this->addFieldToArray($new, $value, 'settings.startingpoint');


### PR DESCRIPTION
otherwise backPid is not migrated, tested with news 7.0.8